### PR TITLE
Fix for Cider 3.0 

### DIFF
--- a/apple-music-widget/script.js
+++ b/apple-music-widget/script.js
@@ -44,6 +44,9 @@ function connectws() {
 				// Song changes
 				case ("playbackStatus.nowPlayingItemDidChange"):
 					UpdateSongInfo(data);
+					setTimeout(() => {
+						SetVisibility(true);
+					}, animationSpeed * 500);
 					break;
 
 				// Progress bar moves


### PR DESCRIPTION
Cider 3.0 only send nowPlayingItemDidChange when it automatically switches to the next track (previous versions also sent playbackStateDidChange / playing which triggered the display)